### PR TITLE
Fix logging path in service definition

### DIFF
--- a/service/log/run
+++ b/service/log/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 exec 2>&1
-exec multilog t s25000 n4 /var/log/dbus-sun2000
+exec multilog t s25000 n4 /var/log/dbus-huaweisun2000


### PR DESCRIPTION
Fix /var/log path to be in sync with README.md and the overall naming scheme