### PR TITLE
Add config option for modbus unit

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,6 +7,9 @@ HOST = "192.168.200.1"
 # Default Port: 6607 / Old firmware has 502
 PORT = 6607
 
+# Default modbus unit: 0 (may need 1 for some inverters or even higher number if using a SmartLogger)
+MODBUS_UNIT = 0
+
 # Uncomment for no custom name
 CUSTOM_NAME = "Huawei SUN2000"
 

--- a/connector_modbus.py
+++ b/connector_modbus.py
@@ -4,8 +4,8 @@ from sun2000_modbus import registers
 import config
 
 class ModbusDataCollector2000Delux:
-    def __init__(self, host='192.168.200.1', port=6607):
-        self.invSun2000 = inverter.Sun2000(host=host, port=port)
+    def __init__(self, host='192.168.200.1', port=6607, modbus_unit=0):
+        self.invSun2000 = inverter.Sun2000(host=host, port=port, modbus_unit=modbus_unit)
 
     # def isConnected(self):
     #     return
@@ -85,7 +85,9 @@ class ModbusDataCollector2000Delux:
 
 ## Just for testing ##
 if __name__ == "__main__":
-    inverter = inverter.Sun2000(host=config.HOST, port=config.PORT)
+    if not hasattr(config, 'MODBUS_UNIT'):
+        config.MODBUS_UNIT = 0
+    inverter = inverter.Sun2000(host=config.HOST, port=config.PORT, modbus_unit=config.MODBUS_UNIT)
     inverter.connect()
     if inverter.isConnected():
 

--- a/dbus-huaweisun2000-pvinverter.py
+++ b/dbus-huaweisun2000-pvinverter.py
@@ -93,7 +93,7 @@ class DbusSun2000Service:
 
 
 def main():
-    modbus = ModbusDataCollector2000Delux(host = config.HOST, port=config.PORT)  # New:6607 old: 502
+    modbus = ModbusDataCollector2000Delux(host = config.HOST, port=config.PORT, modbus_unit=config.MODBUS_UNIT)
     staticdata = modbus.getStaticData()
 
     logging.basicConfig(format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',

--- a/sun2000_modbus/inverter.py
+++ b/sun2000_modbus/inverter.py
@@ -10,9 +10,9 @@ logging.basicConfig(level=logging.INFO)
 
 
 class Sun2000:
-    def __init__(self, host, port=502, timeout=5, wait=2, unit=0): # some models need unit=1
+    def __init__(self, host, port=502, timeout=5, wait=2, modbus_unit=0):
         self.wait = wait
-        self.unit = unit
+        self.modbus_unit = modbus_unit
         self.inverter = ModbusTcpClient(host, port, timeout=timeout)
 
     def connect(self):
@@ -42,9 +42,9 @@ class Sun2000:
             raise ValueError('Inverter is not connected')
 
         try:
-            register_value = self.inverter.read_holding_registers(register.value.address, register.value.quantity, unit=self.unit)
+            register_value = self.inverter.read_holding_registers(register.value.address, register.value.quantity, unit=self.modbus_unit)
             if type(register_value) == ModbusIOException:
-                logging.error("Inverter unit did not respond")
+                logging.error("Inverter modbus unit did not respond")
                 raise register_value
         except ConnectionException:
             logging.error("A connection error occurred")
@@ -84,9 +84,9 @@ class Sun2000:
         if end_address != 0:
             quantity = end_address - start_address + 1
         try:
-            register_range_value = self.inverter.read_holding_registers(start_address, quantity, unit=self.unit)
+            register_range_value = self.inverter.read_holding_registers(start_address, quantity, unit=self.modbus_unit)
             if type(register_range_value) == ModbusIOException:
-                logging.error("Inverter unit did not respond")
+                logging.error("Inverter modbus unit did not respond")
                 raise register_range_value
         except ConnectionException:
             logging.error("A connection error occurred")


### PR DESCRIPTION
Add possibility to configure modbus unit. Also rename the method parameters from unit to modbus_unit in order to avoid confusion with the unit of registers.
This is backwards compatible with config files that don't have this option, so upgrading is safe.

I'm not 100% sure what changes in the last line of config.py, seems like a space or newline encoding change.