### PR TITLE
Allow to change settings through the VenusOS GUI

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,29 +1,6 @@
 import logging
 
 ## CONFIGURATION ##
-# Default IP: 192.168.200.1
-HOST = "192.168.200.1"
-
-# Default Port: 6607 / Old firmware has 502
-PORT = 6607
-
-# Default modbus unit: 0 (may need 1 for some inverters or even higher number if using a SmartLogger)
-MODBUS_UNIT = 0
-
-# Uncomment for no custom name
-CUSTOM_NAME = "Huawei SUN2000"
-
-# Instance Number in VRM
-DEVICE_INSTANCE = 40
-
-# Position: 0 = AC Input, 1 = AC-Out 1, AC-Out 2
-POSITION = 0
-
 # Loglevel: INFO, DEBUG, ERROR
+# FIXME: This should probably also be configured in the GUI
 LOGGING = logging.DEBUG
-
-# Time between calling the update method
-UPDATE_TIME_IN_MS=1000
-
-# power correction factor per phase (in case a little calibration is needed)
-POWER_CORRECTION_FACTOR = 0.995

--- a/dbus-huaweisun2000-pvinverter.py
+++ b/dbus-huaweisun2000-pvinverter.py
@@ -17,7 +17,9 @@ import sys
 import time
 import os
 import config
+from dbus.mainloop.glib import DBusGMainLoop
 from connector_modbus import ModbusDataCollector2000Delux
+from settings import HuaweiSUN2000Settings
 
 # our own packages from victron
 sys.path.insert(1, os.path.join(os.path.dirname(__file__), '/opt/victronenergy/dbus-systemcalc-py/ext/velib_python'))
@@ -25,13 +27,13 @@ from vedbus import VeDbusService
 
 
 class DbusSun2000Service:
-    def __init__(self, servicename, deviceinstance, position, paths, data_connector, serialnumber='X',
+    def __init__(self, servicename, settings, paths, data_connector, serialnumber='X',
                  productname='Huawei Sun2000 PV-Inverter'):
         self._dbusservice = VeDbusService(servicename)
         # self._paths = paths
         self._data_connector = data_connector
 
-        logging.debug("%s /DeviceInstance = %d" % (servicename, deviceinstance))
+        logging.debug("%s /DeviceInstance = %d" % (servicename, settings.get_vrm_instance()))
 
         # productname="Huawei Sun2000" #tmp please del
 
@@ -42,10 +44,10 @@ class DbusSun2000Service:
         self._dbusservice.add_path('/Mgmt/Connection', 'Internal Wifi Modbus TCP')
 
         # Create the mandatory objects
-        self._dbusservice.add_path('/DeviceInstance', deviceinstance)
+        self._dbusservice.add_path('/DeviceInstance', settings.get_vrm_instance())
         self._dbusservice.add_path('/ProductId', 0)  # Huawei does not have a product id
         self._dbusservice.add_path('/ProductName', productname)
-        self._dbusservice.add_path('/CustomName', config.CUSTOM_NAME if hasattr(config, 'CUSTOM_NAME') else None)
+        self._dbusservice.add_path('/CustomName', settings.get("custom_name"))
         self._dbusservice.add_path('/FirmwareVersion', 1.0)
         self._dbusservice.add_path('/HardwareVersion', 0)
         self._dbusservice.add_path('/Connected', 1, writeable=True)
@@ -53,18 +55,18 @@ class DbusSun2000Service:
         # Create the mandatory objects
         self._dbusservice.add_path('/Latency', None)
         self._dbusservice.add_path('/Role', "pvinverter")
-        self._dbusservice.add_path('/Position', position)  # 0 = AC Input, 1 = AC-Out 1, AC-Out 2
+        self._dbusservice.add_path('/Position', settings.get("position"))  # 0 = AC Input, 1 = AC-Out 1, AC-Out 2
         self._dbusservice.add_path('/Serial', serialnumber)
         self._dbusservice.add_path('/ErrorCode', 0)
         self._dbusservice.add_path('/UpdateIndex', 0)
         self._dbusservice.add_path('/StatusCode', 7)
 
-        for path, settings in paths.items():
+        for _path, _settings in paths.items():
             self._dbusservice.add_path(
-                path, settings['initial'], gettextcallback=settings['textformat'], writeable=True,
+                _path, _settings['initial'], gettextcallback=_settings['textformat'], writeable=True,
                 onchangecallback=self._handlechangedvalue)
 
-        GLib.timeout_add(config.UPDATE_TIME_IN_MS, self._update)  # pause in ms before the next request
+        GLib.timeout_add(settings.get('update_time_ms'), self._update)  # pause in ms before the next request
 
     def _update(self):
         with self._dbusservice as s:
@@ -76,7 +78,7 @@ class DbusSun2000Service:
                     logging.info(f"set {k} to {v}")
                     s[k] = v
 
-                # increment UpdateIndex - to show that new data is available an wrap
+                # increment UpdateIndex - to show that new data is available (and wrap)
                 s['/UpdateIndex'] = (s['/UpdateIndex'] + 1) % 256
 
                 # update lastupdate vars
@@ -91,25 +93,58 @@ class DbusSun2000Service:
         logging.debug("someone else updated %s to %s" % (path, value))
         return True  # accept the change
 
+def exit_mainloop(mainloop):
+    mainloop.quit()
 
 def main():
-    modbus = ModbusDataCollector2000Delux(host = config.HOST, port=config.PORT, modbus_unit=config.MODBUS_UNIT)
-    staticdata = modbus.getStaticData()
 
+    # FIXME: This should be a proper private logger, instead of trying to configure the root logger,
+    # which doesn't work unless force=True is specified and then leads to all sorts of libraries
+    # logging lots of debug data
     logging.basicConfig(format='%(asctime)s,%(msecs)d %(name)s %(levelname)s %(message)s',
                         datefmt='%Y-%m-%d %H:%M:%S',
                         level=config.LOGGING,
                         handlers=[
                             logging.StreamHandler()
                         ])
+
+    # Have a mainloop, so we can send/receive asynchronous calls to and from dbus
+    DBusGMainLoop(set_as_default=True)
+
+    settings = HuaweiSUN2000Settings()
+    logging.info(f"VRM pvinverter instance: {settings.get_vrm_instance()}")
+    logging.info(f"Settings: ModbusHost '{settings.get('modbus_host')}', ModbusPort '{settings.get('modbus_port')}', ModbusUnit '{settings.get('modbus_unit')}'")
+    logging.info(f"Settings: CustomName '{settings.get('custom_name')}', Position '{settings.get('position')}', UpdateTimeMS '{settings.get('update_time_ms')}'")
+    logging.info(f"Settings: PowerCorrectionFactor '{settings.get('power_correction_factor')}'")
+
+    while "255" in settings.get("modbus_host"):
+        # This catches the initial setting and allows the service to be installed without configuring it first
+        logging.warning(f"Please configure the modbus host and other settings in the VenusOS GUI (current setting: {settings.get('modbus_host')})")
+        # Running a mainloop means we'll be notified about config changes and exit in that case (which restarts the service)
+        mainloop = GLib.MainLoop()
+        mainloop.run()
+
+    modbus = ModbusDataCollector2000Delux(host = settings.get("modbus_host"),
+                                          port=settings.get("modbus_port"),
+                                          modbus_unit=settings.get("modbus_unit"),
+                                          power_correction_factor=settings.get("power_correction_factor"))
+
+    while True:
+        staticdata = modbus.getStaticData()
+        if staticdata is None:
+            logging.error(f"Didn't receive static data from modbus, error is above. Sleeping 10 seconds before retrying.")
+            # Again we sleep in the mainloop in order to pick up config changes
+            mainloop = GLib.MainLoop()
+            GLib.timeout_add(10000, exit_mainloop, mainloop)
+            mainloop.run()
+            continue
+        else:
+            break
+
     try:
-        logging.info("Start");
+        logging.info("Starting up");
 
-        from dbus.mainloop.glib import DBusGMainLoop
-        # Have a mainloop, so we can send/receive asynchronous calls to and from dbus
-        DBusGMainLoop(set_as_default=True)
-
-        # # formatting
+        # formatting
         _kwh = lambda p, v: (str(round(v, 2)) + ' kWh')
         _a = lambda p, v: (str(round(v, 1)) + ' A')
         _w = lambda p, v: (str(round(v, 1)) + ' W')
@@ -146,8 +181,7 @@ def main():
 
         pvac_output = DbusSun2000Service(
             servicename='com.victronenergy.pvinverter.sun2000',
-            deviceinstance=config.DEVICE_INSTANCE,
-            position=config.POSITION,
+            settings=settings,
             paths=dbuspath,
             productname=staticdata['Model'],
             serialnumber=staticdata['SN'],

--- a/gui/PageSettingsHuaweiSUN2000.qml
+++ b/gui/PageSettingsHuaweiSUN2000.qml
@@ -1,0 +1,78 @@
+import QtQuick 1.1
+import com.victron.velib 1.0
+import "utils.js" as Utils
+
+MbPage {
+	title: qsTr("Huawei SUN2000")
+	property string settings: "com.victronenergy.settings/Settings/HuaweiSUN2000"
+
+	model: VisibleItemModel {
+                MbEditBoxIp {                                                    
+                        id: modbusHost
+                        description: qsTr("Modbus host IP")
+                        item.bind: Utils.path(settings, "/ModbusHost")
+                }                                                    
+
+		MbEditBox {
+			id: modbusPort
+			description: qsTr("Modbus port")
+			matchString: " 0123456789"
+			numericOnlyLayout: true
+			item.bind: Utils.path(settings, "/ModbusPort")
+
+			function editTextToValue() {
+				return parseInt(_editText, 10)
+			}
+		}
+
+		MbEditBox {
+			id: modbusUnit
+			description: qsTr("Modbus unit")
+			matchString: " 0123456789"
+			numericOnlyLayout: true
+			item.bind: Utils.path(settings, "/ModbusUnit")
+
+			function editTextToValue() {
+				return parseInt(_editText, 10)
+			}
+		}
+
+                MbEditBox {                                                    
+                        id: customName
+                        description: qsTr("Custom Name")
+                        item.bind: Utils.path(settings, "/CustomName")
+                }                                                    
+
+                MbItemOptions {
+                        description: qsTr("Position")
+                        bind: Utils.path(settings, "/Position")
+                        possibleValues: [
+                                MbOption { description: qsTr("AC Input 1"); value: 0 },
+                                MbOption { description: qsTr("AC Input 2"); value: 2 },
+                                MbOption { description: qsTr("AC Output"); value: 1 }
+                        ]
+                }
+
+		MbEditBox {
+			id: updateTimeMS
+			description: qsTr("Update time(ms)")
+			matchString: " 0123456789"
+			numericOnlyLayout: true
+			item.bind: Utils.path(settings, "/UpdateTimeMS")
+
+			function editTextToValue() {
+				return parseInt(_editText, 10)
+			}
+		}
+
+                MbSpinBox {                                
+                    description: qsTr("Power correction factor")
+                    item {
+                        bind: Utils.path(settings, "/PowerCorrectionFactor")
+                        decimals: 3
+                        step: 0.001
+                    }
+                }
+
+	}
+}

--- a/gui/menu_item.txt
+++ b/gui/menu_item.txt
@@ -1,0 +1,10 @@
+                // dbus-huaweisun2000 start
+                MbSubMenu {
+                        id: menuHuaweiSUN2000
+                        description: qsTr("Huawei SUN2000")
+                        subpage: Component {
+                                PageSettingsHuaweiSUN2000 { }
+                        }
+                }
+                // dbus-huaweisun2000 end
+

--- a/install.sh
+++ b/install.sh
@@ -29,3 +29,19 @@ then
 fi
 
 grep -qxF "$SCRIPT_DIR/install.sh" $filename || echo "$SCRIPT_DIR/install.sh" >> $filename
+
+# The "PV inverters" page in Settings is somewhat specific for Fronius. Let's change that.
+invertersSettingsFile="/opt/victronenergy/gui/qml/PageSettingsFronius.qml"
+
+if (( $(grep -c "PageSettingsHuaweiSUN2000" $invertersSettingsFile) > 0)); then
+    echo "INFO: $invertersSettingsFile seems already modified for HuaweiSUN2000 -- skipping modification"
+else
+    echo "INFO: Adding menu entry to $invertersSettingsFile"
+    sed -i "/model: VisibleItemModel/ r $SCRIPT_DIR/gui/menu_item.txt" $invertersSettingsFile
+fi
+
+cp -av $SCRIPT_DIR/gui/*.qml /opt/victronenergy/gui/qml/
+
+# As we've modified the GUI, we need to restart it
+svc -t /service/gui
+

--- a/restart.sh
+++ b/restart.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 echo "SCRIPT_DIR: $SCRIPT_DIR"
-rm $SCRIPT_DIR/current.log
 
 kill $(pgrep -f "python -u $SCRIPT_DIR/dbus-huaweisun2000-pvinverter.py")

--- a/settings.py
+++ b/settings.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+# flake8 --ignore E501,E402 settings.py
+
+import dbus
+import logging
+import os
+import sys
+
+sys.path.insert(1, os.path.join(os.path.dirname(__file__), '/opt/victronenergy/dbus-systemcalc-py/ext/velib_python'))
+from settingsdevice import SettingsDevice
+
+
+class SystemBus(dbus.bus.BusConnection):
+    def __new__(cls):
+        return dbus.bus.BusConnection.__new__(cls, dbus.bus.BusConnection.TYPE_SYSTEM)
+
+
+class SessionBus(dbus.bus.BusConnection):
+    def __new__(cls):
+        return dbus.bus.BusConnection.__new__(cls, dbus.bus.BusConnection.TYPE_SESSION)
+
+
+class HuaweiSUN2000Settings(object):
+
+    def __init__(self):
+        # path, default value, min, max, logging silent or not
+        supported_settings = {
+            "modbus_host": ["/Settings/HuaweiSUN2000/ModbusHost", "192.168.200.255", "", "", 0],
+            "modbus_port": ["/Settings/HuaweiSUN2000/ModbusPort", 6607, 1, 65536, 0],
+            "modbus_unit": ["/Settings/HuaweiSUN2000/ModbusUnit", 0, 0, 247, 0],
+            "custom_name": ["/Settings/HuaweiSUN2000/CustomName", "Huawei SUN2000", "", "", 0],
+            "position": ["/Settings/HuaweiSUN2000/Position", 0, 0, 2, 0],
+            "update_time_ms": ["/Settings/HuaweiSUN2000/UpdateTimeMS", 1000, 100, 10000000, 0],
+            "power_correction_factor": ["/Settings/HuaweiSUN2000/PowerCorrectionFactor", 0.995, 0.001, 100.0, 0],
+            # "HuaweiSUN2000" is our unique id for the moment. This needs some more thought if more than one inverter shall be supported.
+            # Unfortunately we can't use the serial number, because we need the config in order to get that one, so we have a catch-22.
+            "vrm_instance": ["/Settings/Devices/HuaweiSUN2000/ClassAndVrmInstance", "pvinverter:1", "", "", 0],
+        }
+        self.dbus_conn = self._dbusconnection()
+        self.settings = SettingsDevice(bus=self.dbus_conn, supportedSettings=supported_settings, eventCallback=self._handle_changed_setting)
+
+    def _dbusconnection(self):
+        return SessionBus() if "DBUS_SESSION_BUS_ADDRESS" in os.environ else SystemBus()
+
+    def _handle_changed_setting(self, setting, oldvalue, newvalue):
+        logging.info(f"setting changed, setting: {setting}, old: {oldvalue}, new: {newvalue}")
+        logging.info("Exiting due to new setting. The service will get restarted and pick up the new setting.")
+        # I consider this to be a bit of a hack, but it works for now. If there are config changes, the
+        # service exits and gets restarted and thus picks up the new settings values.
+        sys.exit(0)
+
+    def get(self, setting):
+        return self.settings[setting]
+
+    def set(self, setting, value):
+        self.settings[setting] = value
+
+    def get_vrm_instance(self):
+        return int(self.settings["vrm_instance"].split(":")[1])

--- a/sun2000_modbus/inverter.py
+++ b/sun2000_modbus/inverter.py
@@ -25,6 +25,8 @@ class Sun2000:
             else:
                 logging.error('Connection to inverter failed')
                 return False
+        else:
+            return True
 
     def disconnect(self):
         """Close the underlying tcp socket"""


### PR DESCRIPTION
This change allows to configure all parameters (except the log level,
which needs to be fixed at some later point, anyway) through the GUI
under Settings -> PV inverters -> Huawei SUN2000
Note that in order to really uninstall the GUI changes currently a
reboot of the VenusOS is needed. This might be fixed later.