### PR TITLE
Inadverent division of solar yield/3 in single phase

### DIFF
--- a/connector_modbus.py
+++ b/connector_modbus.py
@@ -143,14 +143,16 @@ class ModbusDataCollector2000:
         freq = self.invSun2000.read(self.this_inverter.GridFrequency)
 
         # There is no Modbus register for the phases
-        data['/Ac/L1/Energy/Forward'] = round(energy_forward / 3.0, 2)
         data['/Ac/L1/Frequency'] = freq
 
         if self.system_type == 0:
+            #Single phase inverter
+            data['/Ac/L1/Energy/Forward'] = round(energy_forward, 2)
             data['/Ac/L1/Power'] = float(data['/Ac/Power'])
 
         if self.system_type == 1:
             # Three phase inverter
+            data['/Ac/L1/Energy/Forward'] = round(energy_forward / 3.0, 2)
             data['/Ac/L2/Energy/Forward'] = round(energy_forward / 3.0, 2)
             data['/Ac/L3/Energy/Forward'] = round(energy_forward / 3.0, 2)
             data['/Ac/L2/Frequency'] = freq


### PR DESCRIPTION
Fixed a bug where single phased inverters would still divide solar yield (Active Power L1) by 3 no matter the settings of the driver.